### PR TITLE
fix(everything): Make the app not error

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -76,5 +76,8 @@ module.exports = {
   resolve: {
     plugins: [new TsconfigPathsPlugin()],
     extensions: ['.js', '.ts', '.json'],
+    alias: {
+      'vue$': 'vue/dist/vue.esm.js',
+    }
   },
 }


### PR DESCRIPTION
Apparently you need that alias to make it compile templates at runtime.