### PR TITLE
fix(top-bar): Remove .js file that was breaking the build

### DIFF
--- a/src/components/top-bar.js
+++ b/src/components/top-bar.js
@@ -1,8 +1,0 @@
-"use strict";
-exports.__esModule = true;
-var vue_1 = require("vue");
-var top_bar_html_1 = require("./top-bar.html");
-exports.TopBar = vue_1["default"].component('top-bar', {
-    name: 'TopBar',
-    template: top_bar_html_1["default"]
-});


### PR DESCRIPTION
It was failing during runtime to render the top-bar component for some
reason. Deleting the incorrectly added .js file fixed it.